### PR TITLE
✨🚇 Add Github Action and CI pipeline

### DIFF
--- a/.github/workflows/test-pyglotaran-examples.yml
+++ b/.github/workflows/test-pyglotaran-examples.yml
@@ -1,0 +1,106 @@
+name: "Test pyglotaran examples"
+
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+      - "sourcery/**"
+      - "pre-commit-ci-update-config"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  create-example-list:
+    name: Create Example List
+    runs-on: ubuntu-latest
+    outputs:
+      example-list: ${{ steps.create-example-list.outputs.example-list }}
+    steps:
+      - name: Set example list output
+        id: create-example-list
+        uses: glotaran/pyglotaran-examples@main
+        with:
+          example_name: set example list
+          set_example_list: true
+
+  run-examples:
+    name: "Run Example: "
+    runs-on: ubuntu-latest
+    needs: [create-example-list]
+    strategy:
+      matrix:
+        example_name: ${{fromJson(needs.create-example-list.outputs.example-list)}}
+    steps:
+      - name: Checkout pyglotaran main branch
+        uses: actions/checkout@v3
+        with:
+          repository: "glotaran/pyglotaran"
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install pyglotaran
+        run: |
+          pip install wheel
+          pip install -r requirements_dev.txt
+          pip install .
+      - name: ${{ matrix.example_name }}
+        id: example-run
+        uses: glotaran/pyglotaran-examples@main
+        with:
+          example_name: ${{ matrix.example_name }}
+      - name: Installed packages
+        if: always()
+        run: |
+          pip freeze
+      - name: Upload Example Plots Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: example-plots
+          path: ${{ steps.example-run.outputs.plots-path }}
+
+      - name: Upload Example Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: example-results
+          path: ~/pyglotaran_examples_results
+
+  compare-results:
+    name: Compare Results
+    runs-on: ubuntu-latest
+    needs: [run-examples]
+    steps:
+      - name: Checkout pyglotaran-validation
+        uses: actions/checkout@v3
+      - name: Checkout compare results
+        uses: actions/checkout@v3
+        with:
+          repository: "glotaran/pyglotaran-examples"
+          ref: comparison-results
+          path: comparison-results
+
+      - name: Download result artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: example-results
+          path: comparison-results-current
+
+      - name: Show used versions for result creation
+        run: |
+          echo "::group:: ✔️ Compare-Results"
+          echo "✔️ pyglotaran-examples commit: $(< comparison-results/example_commit_sha.txt)"
+          echo "✔️ pyglotaran commit: $(< comparison-results/pyglotaran_commit_sha.txt)"
+          echo "::endgroup::"
+          echo "::group:: ♻️ Current-Results"
+          echo "♻️ pyglotaran-examples commit: $(< comparison-results-current/example_commit_sha.txt)"
+          echo "::endgroup::"
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Run result validator
+        uses: ./
+        with:
+          validation_name: pyglotaran-examples

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,28 @@
+name: "pyglotaran validation"
+description: "Run pyglotaran validation to confirm validity of results"
+author: "Sebastian Weigand"
+inputs:
+  validation_name:
+    description: "Which validator to run {all, pyglotaran-examples}"
+    default: "all"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install requirements
+      shell: bash
+      run: |
+        pip install -r ${{ github.action_path }}/requirements.txt
+
+    - name: Run all validation tests
+      shell: bash
+      if: inputs.set_example_list == 'all'
+      run: |
+        pytest ${{ github.action_path }}
+
+    - name: Run ${{ inputs.set_example_list }} validation tests
+      shell: bash
+      if: inputs.set_example_list != 'all'
+      run: |
+        pytest ${{ github.action_path }}/${{ inputs.set_example_list }}

--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -60,7 +60,7 @@ class GitError(Exception):
 def get_compare_results_path() -> Path:
     """Ensure that the comparison-results exist, are up to date and return their path."""
     compare_result_folder = REPO_ROOT / "comparison-results"
-    example_repo = "git@github.com:glotaran/pyglotaran-examples.git"
+    example_repo = "https://github.com/glotaran/pyglotaran-examples.git"
     if not compare_result_folder.exists():
         proc_clone = subprocess.run(
             [

--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -112,13 +112,15 @@ def get_compare_results_path() -> Path:
 def get_current_result_path() -> Path:
     """Get the path of the current results."""
     local_path = Path.home() / "pyglotaran_examples_results"
-    ci_path = REPO_ROOT / "comparison-results-current"
+    ci_path = Path(os.getenv("GITHUB_WORKSPACE", "")) / "comparison-results-current"
     if local_path.exists():
         return local_path
     elif ci_path.exists():
         return ci_path
     else:
-        raise ValueError(f"No current results present, {RUN_EXAMPLES_MSG}")
+        raise ValueError(
+            f"No current results present at {local_path} or {ci_path}, {RUN_EXAMPLES_MSG}"
+        )
 
 
 def rename_with_suffix(


### PR DESCRIPTION
This PR adds a github action that allows the validator to be run as part of other pipelines.
And a CI pipeline to test the validator itself and the GHA.
A [successful run can be seen on my fork](https://github.com/s-weigand/pyglotaran-validation/actions/runs/3251445042) but the pipeline won't be run here until it is merged into main.

### Change summary

- [✨ Added github action to run validation](https://github.com/glotaran/pyglotaran-validation/commit/4c6e12f35640d9570c493f3d7487428a988beb43)
- [🩹 Use https url for cloning comparison results](https://github.com/glotaran/pyglotaran-validation/commit/bc1dfe69c222c9b06e852a96fd23b1ea68610b76)
- [🩹 Changed CI path lookup of current results to use GITHUB_WORKSPACE env var](https://github.com/glotaran/pyglotaran-validation/commit/c1817b53d91400589fb19e15446345ab9c92c7e6)
 instead of REPO_ROOT relative to file because actions run in their own folder structure
- [🚇🧪 Added CI pipeline to test 'pyglotaran-examples' validator and GHA](https://github.com/glotaran/pyglotaran-validation/pull/1/commits/f71d5c808966a3815c71eff5d4c8acea2ccdf5c9)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
