### PR TITLE
🔧 Add tooling and gitignore comparison results

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,27 @@
+name: "Run Tests"
+
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+      - "sourcery/**"
+      - "pre-commit-ci-update-config"
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  test-pyglotaran-examples:
+    needs: [pre-commit]
+    uses: ./.github/workflows/test-pyglotaran-examples.yml

--- a/.github/workflows/test-pyglotaran-examples.yml
+++ b/.github/workflows/test-pyglotaran-examples.yml
@@ -1,13 +1,7 @@
 name: "Test pyglotaran examples"
 
 on:
-  push:
-    branches-ignore:
-      - "dependabot/**"
-      - "sourcery/**"
-      - "pre-commit-ci-update-config"
-  pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   create-example-list:

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VSCode config
 .vscode
+
+# pyglotaran-examples results to compare against
+pyglotaran-examples/comparison-results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,92 @@
+ci:
+  skip: [interrogate]
+
+repos:
+  # Formatters
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+      - id: fix-encoding-pragma
+        args: [--remove]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.1.0
+    hooks:
+      - id: pyupgrade
+        types: [file]
+        types_or: [python, pyi]
+        args: [--py38-plus]
+
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+      - id: absolufy-imports
+        exclude: ^benchmark
+        types: [file]
+        types_or: [python, pyi]
+
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        types: [file]
+        types_or: [python, pyi]
+        language_version: python3
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        types: [file]
+        types_or: [python, pyi]
+        minimum_pre_commit_version: 2.9.0
+
+  # Linters
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+      - id: yesqa
+        types: [file]
+        types_or: [python, pyi]
+        additional_dependencies: [flake8-docstrings, flake8-print>=5.0.0]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+        types: [file]
+        types_or: [python, pyi]
+        additional_dependencies:
+          [flake8-pyi, flake8-comprehensions, flake8-print>=5.0.0]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.982
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-all]
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: rst-backticks
+      - id: python-check-blanket-noqa
+        exclude: "docs|tests?"
+      - id: python-check-blanket-type-ignore
+        exclude: "docs|tests?"
+      - id: python-use-type-annotations
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        types: [file]
+        types_or: [python, pyi, markdown, rst, jupyter]
+        args: [-L doas]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # pyglotaran-validation
 This repository holds scripts for cross-validation of pyglotaran against other software
+
+## Repository Structure
+The root of this repository contains a number of folders, one for each software, framework or test suite we validate against.
+
+The primary test suite is contained in [pyglotaran-examples](https://github.com/glotaran/pyglotaran-examples), which tests pyglotaran against itself using a set of examples and case studies that double as integration tests. This test is run as a github action each time a PR is targeting pyglotaran/main and reports back how the results from running the examples compares to the last defined.
+
+Other software we (partially) validate against, manually, on-demand or automated are:
+- paramGUI ([data](https://github.com/glotaran/pyglotaran-validation-data-paramGUI))
+- TIMP ([data](https://github.com/glotaran/pyglotaran-validation-data-TIMP))
+- TIM ([data](https://github.com/glotaran/pyglotaran-validation-data-TIM))
+
+(^ these will be added in the future)

--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -253,7 +253,7 @@ def data_var_test(
             expected_values = expected_values.transpose(*current_values.dims)
         rtol = 1e-4  # instead of 1e-5
         eps = 1e-5  # instead of ~1.2e-7
-        pre_fix = SVD_PATTERN.match(expected_var_name).group(  # type:ignore[operator]
+        pre_fix = SVD_PATTERN.match(expected_var_name).group(  # type:ignore[union-attr]
             "pre_fix"
         )
         expected_singular_values = expected_result.data_vars[f"{pre_fix}singular_values"]
@@ -307,8 +307,8 @@ def data_var_test(
 def map_result_files(file_glob_pattern: str) -> dict[str, list[tuple[Path, Path]]]:
     """Load all datasets and map them in a dict."""
     result_map = defaultdict(list)
-    if os.getenv("COMPARE_RESULTS_LOCAL"):
-        compare_results_path = Path(os.getenv(key="COMPARE_RESULTS_LOCAL"))
+    if (compare_results_path_str := os.getenv("COMPARE_RESULTS_LOCAL")) is not None:
+        compare_results_path = Path(compare_results_path_str)
         warn(
             dedent(
                 f"""

--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from xarray.core.coordinates import DataArrayCoordinates
 
 
-REPO_ROOT = Path(__file__).parent.parent
+HERE = Path(__file__).parent
 RUN_EXAMPLES_MSG = (
     "run 'python scripts/run_examples.py run-all --headless' "
     "in the 'pyglotaran-examples' repo root."
@@ -59,7 +59,7 @@ class GitError(Exception):
 
 def get_compare_results_path() -> Path:
     """Ensure that the comparison-results exist, are up to date and return their path."""
-    compare_result_folder = REPO_ROOT / "comparison-results"
+    compare_result_folder = HERE / "comparison-results"
     example_repo = "https://github.com/glotaran/pyglotaran-examples.git"
     if not compare_result_folder.exists():
         proc_clone = subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.black]
+line-length = 99
+target-version = ['py38']
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "hug"
+src_paths = ["*"]
+line_length = 99
+include_trailing_comma = true
+force_single_line = true
+remove_redundant_aliases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,9 @@ line_length = 99
 include_trailing_comma = true
 force_single_line = true
 remove_redundant_aliases = true
+
+
+[tool.mypy]
+ignore_missing_imports = true
+scripts_are_modules = true
+show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py310']
 exclude = '''
 /(
     \.eggs

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[flake8]
+extend-ignore = E231, E203
+max-line-length = 99
+per-file-ignores =
+    # imported but unused
+    __init__.py: F401
+    # max line length
+    docs/source/conf.py: E501
+    # Typedef files are formatted differently
+    *.pyi: E301, E302, F401
+    # Allow printing in test file
+    test_*.py: T201
+    # Temporarily deactivated since the code will be removed in PR 1060
+    glotaran/optimization/optimization_group_calculator_linked.py: C417

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,5 @@
 extend-ignore = E231, E203
 max-line-length = 99
 per-file-ignores =
-    # imported but unused
-    __init__.py: F401
-    # max line length
-    docs/source/conf.py: E501
-    # Typedef files are formatted differently
-    *.pyi: E301, E302, F401
     # Allow printing in test file
     test_*.py: T201
-    # Temporarily deactivated since the code will be removed in PR 1060
-    glotaran/optimization/optimization_group_calculator_linked.py: C417


### PR DESCRIPTION
This change allows to use `pyglotaran-validation` as a git submodule by ignoring the comparison-results folder cloned when running the test.
And adds tooling to keep up code quality.

### Change summary

- [🔧 Added config for black and isort](https://github.com/glotaran/pyglotaran-validation/commit/cd01315fb7f95072c393db7cb13bbb2201acdbfd)
- [👌 Changed path comparison-results gets cloned to next to script](https://github.com/glotaran/pyglotaran-validation/commit/a30552a3d0693aced255418335cebef902ff399a)
- [🔧 Added pre-commit config, mypy+flake8 config and solved issues](https://github.com/glotaran/pyglotaran-validation/commit/2173faf6bfe542fd552e0601e697f9c60839fc50)
- [👌🚇 Added pre-commit CI job and workflow_call for other workflows](https://github.com/glotaran/pyglotaran-validation/commit/0c48ac4341697ea7cff5e52c5307b68b173f75d1)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)