### PR TITLE
🚇🧪 Add self consistency test with comparison-results

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,10 +17,12 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,8 @@ on:
       - "pre-commit-ci-update-config"
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 22 * * 5"
 
 jobs:
   pre-commit:

--- a/.github/workflows/test-pyglotaran-examples.yml
+++ b/.github/workflows/test-pyglotaran-examples.yml
@@ -4,9 +4,35 @@ on:
   workflow_call:
 
 jobs:
+  self-consistency:
+    name: Self consistency test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pyglotaran-validation
+        uses: actions/checkout@v3
+      - name: Checkout compare results to comparison-results
+        uses: actions/checkout@v3
+        with:
+          repository: "glotaran/pyglotaran-examples"
+          ref: comparison-results
+          path: comparison-results
+
+      - name: Checkout compare results to comparison-results-current
+        uses: actions/checkout@v3
+        with:
+          repository: "glotaran/pyglotaran-examples"
+          ref: comparison-results
+          path: comparison-results-current
+
+      - name: Run result validator
+        uses: ./
+        with:
+          validation_name: pyglotaran-examples
+
   create-example-list:
     name: Create Example List
     runs-on: ubuntu-latest
+    needs: [self-consistency]
     outputs:
       example-list: ${{ steps.create-example-list.outputs.example-list }}
     steps:
@@ -95,6 +121,20 @@ jobs:
           python-version: "3.10"
 
       - name: Run result validator
+        uses: ./
+        with:
+          validation_name: pyglotaran-examples
+
+      - name: Remove comparison-results
+        run: rm -rf comparison-results
+
+      - name: Download result artifact to comparison-results
+        uses: actions/download-artifact@v3
+        with:
+          name: example-results
+          path: comparison-results
+
+      - name: Test validator new result parsing
         uses: ./
         with:
           validation_name: pyglotaran-examples

--- a/.github/workflows/test-pyglotaran-examples.yml
+++ b/.github/workflows/test-pyglotaran-examples.yml
@@ -122,13 +122,9 @@ jobs:
           validation_name: pyglotaran-examples
 
       - name: Remove comparison-results
-        run: rm -rf comparison-results
-
-      - name: Download result artifact to comparison-results
-        uses: actions/download-artifact@v3
-        with:
-          name: example-results
-          path: comparison-results
+        run: |
+          rm -rf comparison-results
+          cp -r comparison-results-current comparison-results
 
       - name: Test validator new result parsing
         uses: ./

--- a/.github/workflows/test-pyglotaran-examples.yml
+++ b/.github/workflows/test-pyglotaran-examples.yml
@@ -17,12 +17,8 @@ jobs:
           ref: comparison-results
           path: comparison-results
 
-      - name: Checkout compare results to comparison-results-current
-        uses: actions/checkout@v3
-        with:
-          repository: "glotaran/pyglotaran-examples"
-          ref: comparison-results
-          path: comparison-results-current
+      - name: Copy comparison-results to comparison-results-current
+        run: cp -r comparison-results comparison-results-current
 
       - name: Run result validator
         uses: ./

--- a/.github/workflows/test-pyglotaran-examples.yml
+++ b/.github/workflows/test-pyglotaran-examples.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - name: Checkout pyglotaran-validation
         uses: actions/checkout@v3
+
       - name: Checkout compare results to comparison-results
         uses: actions/checkout@v3
         with:
@@ -51,6 +52,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: "glotaran/pyglotaran"
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -60,15 +62,18 @@ jobs:
           pip install wheel
           pip install -r requirements_dev.txt
           pip install .
+
       - name: ${{ matrix.example_name }}
         id: example-run
         uses: glotaran/pyglotaran-examples@main
         with:
           example_name: ${{ matrix.example_name }}
+
       - name: Installed packages
         if: always()
         run: |
           pip freeze
+
       - name: Upload Example Plots Artifact
         uses: actions/upload-artifact@v3
         with:
@@ -88,6 +93,7 @@ jobs:
     steps:
       - name: Checkout pyglotaran-validation
         uses: actions/checkout@v3
+
       - name: Checkout compare results
         uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 repos:
   # Formatters
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -16,7 +16,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         types: [file]
@@ -32,7 +32,7 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black
         types: [file]
@@ -40,7 +40,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         types: [file]
@@ -57,7 +57,7 @@ repos:
         additional_dependencies: [flake8-docstrings, flake8-print>=5.0.0]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         types: [file]
@@ -66,13 +66,13 @@ repos:
           [flake8-pyi, flake8-comprehensions, flake8-print>=5.0.0]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.991
     hooks:
       - id: mypy
         additional_dependencies: [types-all]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: rst-backticks
       - id: python-check-blanket-noqa

--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -440,12 +440,14 @@ def test_result_attr_consistency(
     """Result dataset attributes need to be approximately the same."""
     for expected, current, file_name in map_result_data()[0][result_name]:
         for expected_attr_name, expected_attr_value in expected.attrs.items():
+            if expected_attr_name == "source_path":
+                continue
             assert (
                 expected_attr_name in current.attrs.keys()
             ), f"Missing result attribute: {expected_attr_name!r} in {file_name!r}"
 
             if isinstance(expected_attr_value, str):
-                assert expected_attr_value == current.attrs[expected_attr_name]
+                assert expected_attr_value == current.attrs[expected_attr_name], expected_attr_name
             else:
                 assert allclose(
                     expected_attr_value, current.attrs[expected_attr_name], print_fail=20

--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -252,7 +252,7 @@ def data_var_test(
             )
             expected_values = expected_values.transpose(*current_values.dims)
         rtol = 1e-4  # instead of 1e-5
-        eps = 1e-5  # instead of ~1.2e-7
+        eps = 1e-5  # type:ignore[assignment] # instead of ~1.2e-7
         pre_fix = SVD_PATTERN.match(expected_var_name).group(  # type:ignore[union-attr]
             "pre_fix"
         )
@@ -387,7 +387,7 @@ def map_result_parameters() -> dict[str, list[pd.DataFrame]]:
     """Load all optimized parameter files and map them in a dict."""
 
     result_map = defaultdict(list)
-    result_file_map = map_result_files(file_glob_pattern="*.csv")
+    result_file_map = map_result_files(file_glob_pattern="*parameters.csv")
     for key, path_list in result_file_map.items():
         for expected_result_file, current_result_file in path_list:
             compare_df = pd.DataFrame(
@@ -440,7 +440,6 @@ def test_result_attr_consistency(
     """Result dataset attributes need to be approximately the same."""
     for expected, current, file_name in map_result_data()[0][result_name]:
         for expected_attr_name, expected_attr_value in expected.attrs.items():
-
             assert (
                 expected_attr_name in current.attrs.keys()
             ), f"Missing result attribute: {expected_attr_name!r} in {file_name!r}"


### PR DESCRIPTION
This PR adds selfconsistency tests for the original compare results as well as newly created results with pyglotaran main and examples main. This way we ensure that the validation code itself works as expected and keeps working when we update the compare results (e.g. new files are added to the result that might break validation).

It also fixes the crashing validation in `map_result_parameters` because new glotaran results contain `optimization_history.csv` and `parameter_history.csv` which don't have a `label` column

Since the `source_path` is set when loading a dataset with `glotaran.io.load_dataset`, but we read it independently from pyglotaran with `xr.open_dataset` we ignore it when validating.

**note:**
The type ignore is needed because of the difference between numpys 'floating[_32Bit]' and python float.
pyglotaran-examples/test_result_consistency.py:255: error: Incompatible types in assignment (expression has type "float", variable has type "floating[_32Bit]")  [assignment]

### Change summary

- [🩹 Exclude optimization_history.csv and parameter_history.csv from map_result_parameters](https://github.com/glotaran/pyglotaran-validation/commit/d9ce2f2fc2a4ee743182828e4c4bb3bb3a5dbb9d)
- [🚇🧪 Add self consistency test with comparison-results](https://github.com/glotaran/pyglotaran-validation/pull/3/commits/b2c45e8a9c99b82627fa16c6b939bf5e4ab08df0)
- 🚇🧪 Add self consistency test with new results
- 🚇👌 Run 'Test pyglotaran examples' on schedule
- [⬆️🔧 Update pre-commit config so isort does not crash on installation](https://github.com/glotaran/pyglotaran-validation/pull/3/commits/93c99e4902dcc0da44d3b0f962eecab5b4b5f020)
- [🩹 Exclude source_path dataset attribute from tests](https://github.com/glotaran/pyglotaran-validation/pull/3/commits/4754bd06ddd90bf24fe02224731f1ae7e9e35afe)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)