### PR TITLE
🩹 Fix checking if numpy values are string

### DIFF
--- a/pyglotaran-examples/test_result_consistency.py
+++ b/pyglotaran-examples/test_result_consistency.py
@@ -185,7 +185,7 @@ def coord_test(
             f"data_var {data_var_name!r}"
         )
 
-        if exact_match or expected_coord_value.data.dtype == object:
+        if exact_match or np.issubdtype(expected_coord_value.data.dtype, np.str_):
             assert np.array_equal(expected_coord_value, current_coord_value), (
                 f"Coordinate value mismatch in {file_name!r}, "
                 f"data_var {data_var_name!r} and {expected_coord_name=}"


### PR DESCRIPTION
When comparing coordinates that have string values (e.g. `species`) we need to compare arrays for equality instead of using `all_close`.
Using `object` to determine if an array `dtype` is a string worked in the past but stopped working with `numpy==1.26.2` (see [CI run](https://github.com/glotaran/pyglotaran/actions/runs/6910149662/job/18802840838?pr=1395)), so we need to change the way how we determine if an array has string values.
[I used this change on my fork to check that the CI actually passes.](https://github.com/s-weigand/pyglotaran/actions/runs/6937015108/job/18870496612)

### Change summary

- [🩹 Fix checking if numpy values are string](https://github.com/glotaran/pyglotaran-validation/commit/bed562fad88d5325343454943905a2473521803c)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
